### PR TITLE
Add AI controllers configuration

### DIFF
--- a/.github/ai-controllers.json
+++ b/.github/ai-controllers.json
@@ -1,0 +1,4 @@
+{
+  "controllers": ["jtr4v", "justaddcoffee"],
+  "fallback_controllers": ["jtr4v"]
+}


### PR DESCRIPTION
- Add .github/ai-controllers.json to define who can control the AI agent
- Allows jtr4v and justaddcoffee to use @alzassistant mentions
- Required for GitHub Actions AI agent workflow to function
