### PR TITLE
Fix .gooseignore blocking data access

### DIFF
--- a/.config/goose/.gooseignore
+++ b/.config/goose/.gooseignore
@@ -1,0 +1,5 @@
+# Block only sensitive files, allow everything else
+.env
+*.key
+*.pem
+secrets/


### PR DESCRIPTION
Fixes the MCP error that was blocking the AI agent from accessing the curated papers in data/alz_papers_3k_text/.

Creates a .gooseignore file that only blocks sensitive files (.env, *.key, *.pem, secrets/) while allowing access to all data.